### PR TITLE
Small design changes

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -174,7 +174,7 @@ class EDD_HS_Endpoint {
 
 			$output .= '<div class="toggle indent">';
 			$output .= '<p><span class="muted">' . $order['date'] . '</span><br/>';
-			$output .= trim( edd_currency_filter() ) . $order['amount'] . ( ( isset( $order['payment_method'] ) && '' != $order['payment_method'] ) ?  ' - ' . $order['payment_method'] : '' ) . '</p>';
+			$output .= trim( edd_currency_filter( $order['amount'] ) ) . ( ( isset( $order['payment_method'] ) && '' != $order['payment_method'] ) ?  ' - ' . $order['payment_method'] : '' ) . '</p>';
 
 			if ( ! empty( $order['downloads'] ) && count( $order['downloads'] ) > 0 ) {
 				// buid list of items with license keys


### PR DESCRIPTION
Show `manual_purchases` as `manual`
Don't show "-" before payment method when payment method unset
Show currency symbol instead of name (so $ instead of USD)
