### PR TITLE
Update payments query for EDD 3.0 compatibility #65

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -609,6 +609,7 @@ class Endpoint {
 				}
 				break;
 			case 'manual_purchases':
+			case 'manual' :
 				$payment_method = 'Manual';
 				break;
 			default:

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -268,7 +268,7 @@ class Endpoint {
 					$order_items[ $order_item->cart_index ] = array(
 						'title'        => $order_item->product_name,
 						'price_option' => ! empty( $order_item->price_id ) ? edd_get_price_name( $order_item->price_id ) : '',
-						'is_upgrade'   => (bool) edd_get_order_item_meta( $order_item->id, 'is_upgrade', true ),
+						'is_upgrade'   => (bool) edd_get_order_item_meta( $order_item->id, '_option_is_upgrade', true ),
 						'files'        => edd_get_download_files( $order_item->product_id, $order_item->price_id )
 					);
 				}


### PR DESCRIPTION
Closes #65 

## Changes

- `query_customer_payments()`
    - Performs a new orders query if on EDD 3.0. If on EDD 2.x then the old query is still run unchanged.
    - In EDD 3.0, the return value of this method is now an array of `EDD\Orders\Order` objects instead of order (payment) IDs. I thought this would be okay as it's a private method.
- `get_customer_orders()`
    - Refactored to support that the result of the query method could be an array of Order objects. There are a few new conditional statements to handle that when formatting the data. Working with Order objects here was an optional move, but it avoids the performance hit that comes from still using `EDD_Payment` objects instead.
- `get_payment_method()`
    - The method has been reworked slightly to support that the parameter could be either an Order object or an EDD_Payment object.
    - Added `manual` to the switch statement along with `manual_purchases`. In EDD 3.0 the manual payments gateway has been merged into core, but the key is just `manual`.

I took a few screenshots to show the data still returns the same.

## EDD 2.10

### `master` branch

![helpscout-master](https://user-images.githubusercontent.com/6324272/114527720-3242a300-9c40-11eb-8da4-5ec068f7c72b.png)

### `issue/65`

![helpscout-pr-v2](https://user-images.githubusercontent.com/6324272/114527741-3a024780-9c40-11eb-8e20-2da742fdf7ca.png)

## EDD 3.0

This is a different customer from the above because the data is coming from another install, but shows everything still fundamentally works.

Note: Order 3 has no product title because it actually was an order with no items.

![helpscout-pr-v3-1](https://user-images.githubusercontent.com/6324272/114527823-50a89e80-9c40-11eb-9dda-53d13defb20e.png)
![helpscout-pr-v3-2](https://user-images.githubusercontent.com/6324272/114527825-51413500-9c40-11eb-91c4-8d9c36431a06.png)

### Upgrade

![helpscout-pr-v3-upgrade](https://user-images.githubusercontent.com/6324272/114530006-75057a80-9c42-11eb-88b3-ade7c055a1ca.png)

---

@robincornett can you look over this before I mark it as ready for review?