### PR TITLE
Updates customer email filtration

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -130,7 +130,7 @@ class Endpoint {
 	private function get_edd_customers() {
 		$customers = array();
 
-		$helpscout_emails = $this->data['customer']['emails'];
+		$helpscout_emails = apply_filters( 'edd_helpscout_customer_emails', $this->data['customer']['emails'], $this->data );
 		foreach ($helpscout_emails as $email) {
 			$customer = new EDD_Customer( $email );
 			if ( $customer->id == 0 || !empty($customers[$customer->id]) ) {


### PR DESCRIPTION
This is a duplicate application of the hook to filter customer emails https://github.com/webzunft/edd-helpscout/blob/v2.1/includes/class-endpoint.php#L172 but it's necessary to ensure that the retrieved EDD Customers take into consideration the filtered emails.

Without this filter application the EDD Customer retrieval happens before the email addresses are filtered. With this filter application added we're able to filter the expected customer email addresses right away, before the EDD Customer retrieval happens.