### PR TITLE
Display lifetime license status

### DIFF
--- a/views/licenses.php
+++ b/views/licenses.php
@@ -9,7 +9,11 @@
 					<li class="c-sb-list-item" style="font-style: italic;">
 						<span class="c-sb-list-item__text t-tx-charcoal-500" style="font-size: 11px;">
 						<span class="badge <?= $license['status_color'] ?>" style="font-size: 10px; padding: 3px 4px; margin: 0 4px 0 0;"><?= $license['status'] ?></span>
-						<?= $license['is_expired'] ? __( 'Expired', 'edd-helpscout' ) : __( 'Expires', 'edd-helpscout' ); ?>: <?= $license['expires'] ?>
+						<?php if ( ! empty( $license['is_lifetime'] ) ) : ?>
+							<?= __( 'Lifetime', 'edd-helpscout' ); ?>
+						<?php else : ?>
+							<?= $license['is_expired'] ? __( 'Expired', 'edd-helpscout' ) : __( 'Expires', 'edd-helpscout' ); ?>: <?= $license['expires'] ?>
+						<?php endif; ?>
 						</span>
 					</li>
 				<?php endif ?>


### PR DESCRIPTION
Currently, the plugin displays "Expires: -" for lifetime licenses, which is not intuitive.
This fixes #60 but feel free to tweak it if you'd like.