### PR TITLE
Make toggle states persist and display item counts

### DIFF
--- a/views/licenses.php
+++ b/views/licenses.php
@@ -1,6 +1,6 @@
-<div class="c-sb-section c-sb-section--toggle nested open">
+<div class="c-sb-section c-sb-section--toggle nested open is-persisted">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
-		<i class="icon-folder icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Licenses', 'edd-helpscout' ); ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
+		<i class="icon-folder icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Licenses', 'edd-helpscout' ); ?> <?= '(' . count( $licenses ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>
 	<div class="c-sb-section__body" style="padding-top: 2px;">
 		<?php foreach ($licenses as $license_id => $license): ?>
@@ -118,4 +118,3 @@
 		<?php endforeach ?>
 	</div>
 </div>
-

--- a/views/orders.php
+++ b/views/orders.php
@@ -1,6 +1,6 @@
-<div class="c-sb-section c-sb-section--toggle <?= $toggle ?>">
+<div class="c-sb-section c-sb-section--toggle <?= $toggle ?> is-persisted">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
-		<i class="icon-cart icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Orders', 'edd-helpscout' ); ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
+		<i class="icon-cart icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Orders', 'edd-helpscout' ); ?> <?= '(' . count( $orders ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>
 	<div class="c-sb-section__body">
 		<ul class="c-sb-list c-sb-list--compact" style="padding-bottom: 0;">

--- a/views/subscriptions.php
+++ b/views/subscriptions.php
@@ -1,6 +1,6 @@
-<div class="c-sb-section c-sb-section--toggle">
+<div class="c-sb-section c-sb-section--toggle is-persisted">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
-		<i class="icon-star icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Subscriptions', 'edd-helpscout' ); ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
+		<i class="icon-star icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Subscriptions', 'edd-helpscout' ); ?> <?= '(' . count( $subscriptions ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>
 	<div class="c-sb-section__body">
 		<ul class="c-sb-list c-sb-list--compact" style="padding-top: 16px;">


### PR DESCRIPTION
Make the toggle state for Licenses, Orders, and Subscriptons sections be persistent.
Also, display the number of items/objects found for each section in the heading to help with usability.