### PR TITLE
Improved extensibility

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -347,6 +347,8 @@ class Endpoint {
 
 			$orders[ $payment->ID ] = array(
 				'id'             => $payment->ID,
+				'key'            => $payment instanceof Order ? $payment->payment_key : $payment->key,
+				'email'          => $payment->email,
 				'total'          => edd_payment_amount( $payment->ID ),
 				'items'          => $order_items,
 				'payment_method' => $this->get_payment_method( $payment ),

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -587,8 +587,16 @@ class Endpoint {
 	}
 
 	public function get_template_path( $file ) {
-		$template_base_path = dirname( EDD_HELPSCOUT_FILE ) . '/views';
-		return "{$template_base_path}/{$file}";
+		// check for theme overrides first
+		$template_path = locate_template( 'edd-helpscout/' . $file );
+
+		// fallback to bundled templates
+		if ( empty( $template_path ) ) {
+			$template_base_path = dirname( EDD_HELPSCOUT_FILE ) . '/views';
+			$template_path = "{$template_base_path}/{$file}";
+		}
+
+		return $template_path;
 	}
 
 	/**

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -538,27 +538,32 @@ class Endpoint {
 		if ( empty( $orders ) ) {
 			return sprintf( '<p>No payments found for %s.</p>', '<strong>' . join( '</strong> or <strong>', $this->customer_emails ) . '</strong>' );
 		}
+
+		$html_sections = [];
+
 		// general customer data
 		$customers = $this->get_customer_data();
-		$html = $this->render_template_html( 'customers.php', compact( 'customers' ) );
+		$html_sections['customers'] = $this->render_template_html( 'customers.php', compact( 'customers' ) );
 
 		// customer licenses (EDD Software Licensing)
 		if ( function_exists( 'edd_software_licensing' ) ) {
 			$licenses = $this->get_customer_licenses();
-			$html .= $this->render_template_html( 'licenses.php', compact( 'licenses' ) );
+			$html_sections['licenses'] = $this->render_template_html( 'licenses.php', compact( 'licenses' ) );
 		}
 
 		// customer orders
 		$toggle = function_exists( 'edd_software_licensing' ) ? '' : 'open';
-		$html .= $this->render_template_html( 'orders.php', compact( 'orders', 'toggle' ) );
+		$html_sections['orders'] = $this->render_template_html( 'orders.php', compact( 'orders', 'toggle' ) );
 
 		// customer subscriptions (EDD Recurring)
 		if ( function_exists('EDD_Recurring') ) {
 			$subscriptions = $this->get_customer_subscriptions();
-			$html .= $this->render_template_html( 'subscriptions.php', compact( 'subscriptions' ) );
+			$html_sections['subscriptions'] = $this->render_template_html( 'subscriptions.php', compact( 'subscriptions' ) );
 		}
 
-		return $html;
+		$html_sections = apply_filters( 'edd_helpscout_endpoint_html_sections', $html_sections );
+
+		return apply_filters( 'edd_helpscout_endpoint_html', implode( '', $html_sections ) );
 	}
 
 	/**

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -274,7 +274,9 @@ class Endpoint {
 						'title'        => $order_item->product_name,
 						'price_option' => ! empty( $order_item->price_id ) ? edd_get_price_name( $order_item->price_id ) : '',
 						'is_upgrade'   => (bool) edd_get_order_item_meta( $order_item->id, '_option_is_upgrade', true ),
-						'files'        => edd_get_download_files( $order_item->product_id, $order_item->price_id )
+						'files'        => edd_get_download_files( $order_item->product_id, $order_item->price_id ),
+						'product_id'   => $order_item->product_id,
+						'price_id'     => $order_item->price_id,
 					);
 				}
 			} else {
@@ -288,6 +290,8 @@ class Endpoint {
 						'price_option' => isset( $price_id ) ? edd_get_price_option_name( $item['id'], $price_id, $payment->ID ) : '',
 						'is_upgrade'   => ( ! empty( $item['options']['is_upgrade'] ) ),
 						'files'        => edd_get_download_files( $download->ID, $price_id ),
+						'product_id'   => $download->ID,
+						'price_id'     => $price_id,
 					);
 				}
 			}

--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -561,9 +561,9 @@ class Endpoint {
 			$html_sections['subscriptions'] = $this->render_template_html( 'subscriptions.php', compact( 'subscriptions' ) );
 		}
 
-		$html_sections = apply_filters( 'edd_helpscout_endpoint_html_sections', $html_sections );
+		$html_sections = apply_filters( 'edd_helpscout_endpoint_html_sections', $html_sections, $this->edd_customers, $this->data );
 
-		return apply_filters( 'edd_helpscout_endpoint_html', implode( '', $html_sections ) );
+		return apply_filters( 'edd_helpscout_endpoint_html', implode( '', $html_sections ), $this->edd_customers, $this->data );
 	}
 
 	/**

--- a/views/orders.php
+++ b/views/orders.php
@@ -15,6 +15,7 @@
 					<li class="c-sb-list-item c-sb-list-item--bullet" style="list-style-type: circle; list-style-position: outside; margin-left: 1.2em;padding: 4px 0 6px 0;">
 						<span class="c-sb-list-item__label t-tx-charcoal-500">
 							<strong style="font-size: 14px; line-height: 18px"><?= $item['title'] ?></strong>
+							<?php do_action( 'edd_helpscout_order_list_item_download_details_start', $item, $order, $helpscout_data ); ?>
 							<?php if (!empty($item['price_option'])): ?>
 								<span class="c-sb-list-item__text t-tx-charcoal-500" style="font-size: 11px;"><?= $item['price_option'] ?></span>
 							<?php endif ?>
@@ -23,6 +24,7 @@
 									<span class="badge blue" style="font-size: 9px; padding: 3px 4px; margin-top: 2px;"><?= __( 'License upgrade', 'edd-helpscout' ); ?></span>
 								</span>
 							<?php endif ?>
+							<?php do_action( 'edd_helpscout_order_list_item_download_details_end', $item, $order, $helpscout_data ); ?>
 						</span>
 					</li>
 				<?php endforeach ?>


### PR DESCRIPTION
This makes it easier to add new/custom sections (using the `edd_helpscout_endpoint_html_sections` or `edd_helpscout_endpoint_html` filter) and to customize existing section templates (by copying the template to `{THEME}/edd-helpscout/`).