### PR TITLE
New filters for default toggle state and toggle state persistency

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -544,18 +544,23 @@ class Endpoint {
 
 		// customer licenses (EDD Software Licensing)
 		if ( function_exists( 'edd_software_licensing' ) ) {
+			$toggle = apply_filters( 'edd_helpscout_default_section_toggle', 'open', 'licenses' );
+			$persist = apply_filters( 'edd_helpscout_persist_section_toggle', true, 'licenses' ) ? 'is-persisted' : '';
 			$licenses = $this->get_customer_licenses();
-			$html .= $this->render_template_html( 'licenses.php', compact( 'licenses' ) );
+			$html .= $this->render_template_html( 'licenses.php', compact( 'licenses', 'toggle', 'persist' ) );
 		}
 
 		// customer orders
-		$toggle = function_exists( 'edd_software_licensing' ) ? '' : 'open';
-		$html .= $this->render_template_html( 'orders.php', compact( 'orders', 'toggle' ) );
+		$toggle = apply_filters( 'edd_helpscout_default_section_toggle', function_exists( 'edd_software_licensing' ) ? '' : 'open', 'orders' );
+		$persist = apply_filters( 'edd_helpscout_persist_section_toggle', true, 'orders' ) ? 'is-persisted' : '';
+		$html .= $this->render_template_html( 'orders.php', compact( 'orders', 'toggle', 'persist' ) );
 
 		// customer subscriptions (EDD Recurring)
 		if ( function_exists('EDD_Recurring') ) {
+			$toggle = apply_filters( 'edd_helpscout_default_section_toggle', '', 'subscriptions' );
+			$persist = apply_filters( 'edd_helpscout_persist_section_toggle', true, 'subscriptions' ) ? 'is-persisted' : '';
 			$subscriptions = $this->get_customer_subscriptions();
-			$html .= $this->render_template_html( 'subscriptions.php', compact( 'subscriptions' ) );
+			$html .= $this->render_template_html( 'subscriptions.php', compact( 'subscriptions', 'toggle', 'persist' ) );
 		}
 
 		return $html;

--- a/views/licenses.php
+++ b/views/licenses.php
@@ -1,4 +1,4 @@
-<div class="c-sb-section c-sb-section--toggle nested open is-persisted">
+<div class="c-sb-section c-sb-section--toggle nested <?= $toggle ?> <?= $persist ?>">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
 		<i class="icon-folder icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Licenses', 'edd-helpscout' ); ?> <?= '(' . count( $licenses ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>

--- a/views/orders.php
+++ b/views/orders.php
@@ -1,4 +1,4 @@
-<div class="c-sb-section c-sb-section--toggle <?= $toggle ?> is-persisted">
+<div class="c-sb-section c-sb-section--toggle <?= $toggle ?> <?= $persist ?>">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
 		<i class="icon-cart icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Orders', 'edd-helpscout' ); ?> <?= '(' . count( $orders ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>

--- a/views/subscriptions.php
+++ b/views/subscriptions.php
@@ -1,4 +1,4 @@
-<div class="c-sb-section c-sb-section--toggle is-persisted">
+<div class="c-sb-section c-sb-section--toggle <?= $toggle ?> <?= $persist ?>">
 	<div class="c-sb-section__title js-sb-toggle" style="font-size: 15px; padding: 6px 0 10px 0;">
 		<i class="icon-star icon-sb" style="font-size: 19px; margin-right: 3px; top: 4px;"></i><?= __( 'Subscriptions', 'edd-helpscout' ); ?> <?= '(' . count( $subscriptions ) . ')'; ?><i class="caret sb-caret" style="margin-top: 4px;"></i>
 	</div>


### PR DESCRIPTION
PR #78 introduced the `is-persisted` class to all sections, this PR adds a filter to disable that like so:
```php
add_filter( 'edd_helpscout_persist_section_toggle', '__return_false' );
```
To allow for more fine-grained control, I've also added the section slug to the filter arguments, so that it can be disabled for a specific section. Here's an example that sets the subscriptions section to open by default, and makes sure it's not persisted (in other words, so that even if the user collapses it, it will be open again in the next window):
```php
add_filter( 'edd_helpscout_default_section_toggle', function( $toggle, $section ){
	if ( $section == 'subscriptions' ) {
		$toggle = 'open';
	}
	return $toggle;
}, 10, 2 );
add_filter( 'edd_helpscout_persist_section_toggle', function( $persist, $section ){
	if ( $section == 'subscriptions' ) {
		$persist = false;
	}
	return $persist;
}, 10, 2 );
```