### PR TITLE
Fix: prevent notices for unavailable price IDs in license data

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -424,7 +424,9 @@ class Endpoint {
 
 				if( $license->get_download()->has_variable_prices() && empty( $license->parent ) ) {
 					$prices   = $license->get_download()->get_prices();
-					$license_data['price_option'] = $prices[ $license->price_id ]['name'];
+					if ( isset( $prices[ $license->price_id ] ) ) {
+						$license_data['price_option'] = $prices[ $license->price_id ]['name'];
+					}
 				}
 
 				if ( ! empty( $license->sites ) ) {


### PR DESCRIPTION
When a price ID ('price option') is no longer available (when it used to be available in the past but no longer is), a notice will be thrown:

> PHP Notice:  Undefined offset: # in /wp-content/plugins/edd-helpscout/includes/class-endpoint.php on line 427

This PR fixes that