### PR TITLE
Add new filter to extend output of Licenses > Activated Sites

### DIFF
--- a/views/licenses.php
+++ b/views/licenses.php
@@ -104,6 +104,7 @@
 									<a class="c-sb-list-item__link t-tx-blue-500" href="<?= esc_url( $site['url'] ) ?>"><?= $site['site'] ?></a>
 									<a href="<?= esc_url( $site['deactivate_link'] ); ?>" target="_blank"> <small style="color: red;">(<?= __( 'deactivate', 'edd-helpscout' ) ?>)</small></a>
 								</li>
+								<?php do_action('edd_helpscout_after_licenses_active_site_list_item', $site) ?>
 							<?php endforeach ?>
 						</ul>
 					</div>


### PR DESCRIPTION
We add extra links and information after each activated site, so it would be helpful to have that filter in place to not loose our changes after an update.

