### PR TITLE
Add support for WP timezone to show correct date time in HS sidebar

### DIFF
--- a/includes/class-endpoint.php
+++ b/includes/class-endpoint.php
@@ -687,7 +687,7 @@ class Endpoint {
             $date = new \DateTime( $datetime, new \DateTimeZone( 'UTC' ) );
             $date->setTimezone( $wp_timezone );
             return $date->format( 'Y-m-d H:i:s' ); // Adjust format as needed
-        } catch ( Exception $e ) {
+        } catch ( \Exception $e ) {
             return $datetime; // Fallback to original
         }
     }


### PR DESCRIPTION
We use CEST in WordPress and in EDD. Internally EDD uses UTC, so in Helpscout sidebar the datetime is 2 hours behind the real one. This fixes the problem and outputs the time as CEST (or any other corresponding time that has been setup in WordPress settings)